### PR TITLE
Fixed enchantment info being blocked by descriptions

### DIFF
--- a/src/ItemCardFixer.cpp
+++ b/src/ItemCardFixer.cpp
@@ -32,11 +32,10 @@ void ItemCardFixer::handleSoulLVL()
 		if (!soulStr.empty()) {
 			soulStr = std::string(soulLVL.GetString()) + "\n";
 		}
+		auto soulsDesc = soulStr + this->description;
+		itemInfo.SetMember("description", soulsDesc.c_str());
+		itemInfo.SetMember(ItemCardFixer::typeVar, ItemCardType::ICT_BOOK);
 	}
-
-	auto soulsDesc = soulStr + this->description;
-	itemInfo.SetMember("description", soulsDesc.c_str());
-	itemInfo.SetMember(ItemCardFixer::typeVar, ItemCardType::ICT_BOOK);
 }
 
 void ItemCardFixer::fixHTML(const char* a_displayVariable, const char* a_descriptionVariable)
@@ -354,6 +353,7 @@ void ItemCardFixer::fixCraftEnchanting()
 	fixBackground("SoulLevel");
 
 	fixBackground("EnchantmentLabel");
+	fixBook();
 }
 void ItemCardFixer::fixHousePart()
 {


### PR DESCRIPTION
-Moved soulsDesc to inside the if statement so that it'll only apply the soul gem level handler when soul level is found, this fixes the issue where the description would overwrite the enchantment info during enchanting.
-added "fixBook" into fixCraftEnchanting so that the description colour is applied in the Enchanting menu when applicable.